### PR TITLE
Skip blank lines in the reads file

### DIFF
--- a/METABOLIC-C.pl
+++ b/METABOLIC-C.pl
@@ -1775,17 +1775,17 @@ sub _get_Genome_coverge{
 	open __IN, "$reads";
 	while (<__IN>){
 		chomp;
-		if (!/^#/){
-			my @tmp = split (/\,/,$_);
-			my $tmp_link = "";
-			if ($test ne "true"){
-				$tmp_link = $tmp[0]."\t".$tmp[1];
-			}else{
-				$tmp_link = "$METABOLIC_dir/METABOLIC_test_files/METABOLIC_test_reads/".$tmp[0]."\t"."$METABOLIC_dir/METABOLIC_test_files/METABOLIC_test_reads/".$tmp[1];
-			}
-			$Reads{$tmp_link} = $i;
-			$i++;
+		next if /^#/ or /^\s*$/; # Skip comments and blank lines
+		
+		my @tmp = split /,/;
+		my $tmp_link = "";
+		if ($test ne "true"){
+			$tmp_link = $tmp[0]."\t".$tmp[1];
+		}else{
+			$tmp_link = "$METABOLIC_dir/METABOLIC_test_files/METABOLIC_test_reads/".$tmp[0]."\t"."$METABOLIC_dir/METABOLIC_test_files/METABOLIC_test_reads/".$tmp[1];
 		}
+		$Reads{$tmp_link} = $i;
+		$i++;
 	}
 	close __IN;
 	


### PR DESCRIPTION
My supervisor wasted a lot of time because he had a blank line in the omic-reads file.
Since this is a somewhat common occurrence and it is even pointed out by the authors I thought it would be appropriate for the program to skip blank lines as well as comments when reading said file.
I also cleared the syntax of the split in the following line because... why not, I guess